### PR TITLE
changed munge_fah_data.py and automation.py to handle mTOR data munging 

### DIFF
--- a/FAHMunge/automation.py
+++ b/FAHMunge/automation.py
@@ -84,7 +84,7 @@ def merge_fah_trajectories(input_data_path, output_data_path, top_filename):
     """
     n_runs, n_clones = get_num_runs_clones(input_data_path)
     for run in range(n_runs):
-        top=md.load(os.path.join(top_filename,"RUN%(run)d" % vars(),"system.pdb" ))
+        top=md.load(top_filename % vars())
         for clone in range(n_clones):
             print(run, clone)
             path = os.path.join(input_data_path, "RUN%d" % run, "CLONE%d" % clone)

--- a/FAHMunge/automation.py
+++ b/FAHMunge/automation.py
@@ -63,7 +63,7 @@ def strip_water(path_to_merged_trajectories, output_path, min_num_frames=1):
         topology=t.top.select('protein')
         print("Stripping %s" % in_filename)
         protein_filename = os.path.join(output_path, os.path.basename(in_filename))
-        fah.strip_water(in_filename, plsrotein_filename, topology, min_num_frames=min_num_frames)
+        fah.strip_water(in_filename, protein_filename, topology, min_num_frames=min_num_frames)
         
 
 def merge_fah_trajectories(input_data_path, output_data_path, top_filename):

--- a/FAHMunge/automation.py
+++ b/FAHMunge/automation.py
@@ -39,7 +39,7 @@ def get_num_runs_clones(path):
     return n_runs, n_clones
 
 
-def strip_water(path_to_merged_trajectories, output_path, protein_atom_indices, min_num_frames=1):
+def strip_water(path_to_merged_trajectories, output_path, min_num_frames=1):
     """Strip the water for a set of trajectories.
     
     Parameters
@@ -59,9 +59,11 @@ def strip_water(path_to_merged_trajectories, output_path, protein_atom_indices, 
     """
     in_filenames = glob.glob(os.path.join(path_to_merged_trajectories, "*.h5"))
     for in_filename in in_filenames:
+        t=md.load(in_filename)
+        topology=t.top.select('protein')
         print("Stripping %s" % in_filename)
         protein_filename = os.path.join(output_path, os.path.basename(in_filename))
-        fah.strip_water(in_filename, protein_filename, protein_atom_indices, min_num_frames=min_num_frames)
+        fah.strip_water(in_filename, plsrotein_filename, topology, min_num_frames=min_num_frames)
         
 
 def merge_fah_trajectories(input_data_path, output_data_path, top_filename):
@@ -80,9 +82,9 @@ def merge_fah_trajectories(input_data_path, output_data_path, top_filename):
         for loading the XTC files.
 
     """
-    top = md.load(top_filename)
     n_runs, n_clones = get_num_runs_clones(input_data_path)
     for run in range(n_runs):
+        top=md.load(os.path.join(top_filename,"RUN%(run)d" % vars(),"system.pdb" ))
         for clone in range(n_clones):
             print(run, clone)
             path = os.path.join(input_data_path, "RUN%d" % run, "CLONE%d" % clone)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ The metadata for FAH is a CSV file located here:
 
 /data/choderalab/fah/Software/FAHMunge/projects.csv
 
+
+###Example CSV 
+```
+project,location,pdb
+"10491","/home/server.140.163.4.245/server2/data/SVR2359493877/PROJ10491/","/home/server.140.163.4.245/server2/projects/GPU/p10491/topol-renumbered-explicit.pdb"
+"10492","/home/server.140.163.4.245/server2/data/SVR2359493877/PROJ10492/","/home/server.140.163.4.245/server2/projects/GPU/p10492/topol-renumbered-explicit.pdb"
+"10495","/home/server.140.163.4.245/server2/data/SVR2359493877/PROJ10492/","/home/server.140.163.4.245/server2/projects/GPU/p10495/MTOR_HUMAN_D0/RUN%(run)d/system.pdb"
+```
+pdb points pipeline towards pdb to look at for numbering atoms in the munged data. The top two lines are eamples of using a single pdb for the munging pipeline.
+The third line shows how to use a different pdb for each run. %(run)d is substituted by the run number via filename % vars() in Python, whic allows run numbers 
+or other variables to be substituted. This is done on a per-run basis, not per-clone. 
+
+
 #### Single vs. multi process
 
 There is also a multiprocessing version in the `scripts/` folder.  However,
@@ -67,3 +80,4 @@ plfah1-rsync-no-solvent.log
 plfah2-rsync-all-atoms.log
 plfah2-rsync-no-solvent.log
 ```
+

--- a/scripts/munge_fah_data.py
+++ b/scripts/munge_fah_data.py
@@ -20,9 +20,6 @@ for iteration in itertools.count():
         fahmunge.automation.make_path(allatom_output_path)
         fahmunge.automation.make_path(protein_output_path)
         fahmunge.automation.merge_fah_trajectories(location, allatom_output_path, pdb)
-        trj0 = md.load(pdb)  # Hacky temporary solution to get protein atoms, fix later.
-        top, bonds = trj0.top.to_dataframe()
-        protein_atom_indices = top.index[top.chainID == 0].values    
-        fahmunge.automation.strip_water(allatom_output_path, protein_output_path, protein_atom_indices)
+        fahmunge.automation.strip_water(allatom_output_path, protein_output_path)
     print("Finished iteration %d, sleeping." % iteration)
     time.sleep(3600)


### PR DESCRIPTION
Changed automation.py to pull atoms in protein from trajectory topology and to use a .pdb in each RUN* folder instead of one in the top directory. Removed section of munge_fah_data.py that gathered Protein_atom_indices.