### PR TITLE
Break up trajectory concatenation into smaller chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The third line shows how to use a different PDB for each RUN.
 `%(run)d` is substituted by the run number via `filename % vars()` in Python, which allows run numbers or other local Python variables to be substituted.
 Substitution is only performed on a per-run basis, not per-clone.
 
+The projects CSV file will undergo minimal validation automatically to make sure all data and file paths can be found.
+
 ##### Advanced Usage
 
 More advanced usage allows additional arguments to be specified:
@@ -57,13 +59,14 @@ More advanced usage allows additional arguments to be specified:
 * `--verbose` will produce verbose output
 * `--maxits <MAXITS>` will cause the munging pipeline to run for the specified number of iterations and then exit. This can be useful for debugging. Without specifying this option, munging will run indefinitely.
 * `--sleeptime <SLEEPTIME>` will cause munging to sleep for the specified number of seconds if no work was done in this iteration (default:3600).
+* `--validate` will validate the choice of `topology_selection` MDTraj DSL topology selection queries to make sure they are valid; note that this may take a significant amount of time, so is optional behavior
 
 #### Usage on `choderalab` Folding@home servers
 
 1.  Login to work server using the usual FAH login
 2.  Check if script is running (`screen -r -d`).  If True, stop here.
 3.  Start a screen session
-4.  Run with: `munge-fah-data --projects /data/choderalab/fah/projects.csv --outpath /data/choderalab/fah/munged-data --time 3600 --nprocesses 16`
+4.  Run with: `munge-fah-data --projects /data/choderalab/fah/projects.csv --outpath /data/choderalab/fah/munged-data --time 600 --nprocesses 16`
 5.  To stop, control c when the script is in the "sleep" phase
 
 #### Single vs. multi process

--- a/fahmunge/automation.py
+++ b/fahmunge/automation.py
@@ -49,11 +49,11 @@ def get_num_runs_clones(path):
 
     return n_runs, n_clones
 
-def concatenate_core17_wrapper(args):
+def concatenate_core17_wrapper(kwargs):
     """
     Wrapper for using fah.concatenate_core17 in map.
     """
-    fah.concatenate_core17(*args)
+    fah.concatenate_core17(**kwargs)
 
 def strip_water_wrapper(args):
     """
@@ -115,6 +115,8 @@ def merge_fah_trajectories(input_data_path, output_data_path, top_filename, npro
         If not None, use multiprocessing to parallelize up to the specified number of workers.
 
     """
+    MAXPACKETS = 10 # maximum number of packets to process per iteration
+
     # Build a list of work to parallelize
     n_runs, n_clones = get_num_runs_clones(input_data_path)
     work = collections.deque()
@@ -122,8 +124,13 @@ def merge_fah_trajectories(input_data_path, output_data_path, top_filename, npro
         for clone in range(n_clones):
             path = os.path.join(input_data_path, "RUN%d" % run, "CLONE%d" % clone)
             out_filename = os.path.join(output_data_path, "run%d-clone%d.h5" % (run, clone))
-            args = (path, top_filename % vars(), out_filename)
-            work.append(args)
+            kwargs = {'path' : path, 'top_filename' : top_filename % vars(), 'output_filename' : out_filename}
+            # Set maxpackets and maxtime
+            kwargs['maxpackets'] = MAXPACKETS
+            if maxtime:
+                kwargs['maxtime'] = maxtime
+            # Append work
+            work.append(kwargs)
     print('merging %s : work has %d RUN/CLONE pairs to process' % (input_data_path, len(work)))
 
     print('Using %d threads' % nprocesses)


### PR DESCRIPTION
This breaks up trajectory concatenation into smaller chunks so that safe termination can occur more quickly, and also adds a timeout function that will halt concatenation if a timeout has been exceeded.