### PR TITLE
Infrastructure overhaul for core21 support on v9 workservers

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -46,8 +46,8 @@ test:
     # Testing
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug --validate
     # TODO: Test to make sure expected output is found
-    - ls -ltr munged/all-atoms/11507
-    - ls -ltr munged/no-solvent/11507
+    - ls -ltr munged/11507
+    - ls -ltr munged/11431
     # Test additional processing runs (shouldn't actually do anything)
     - echo "Testing additional processing iterations"
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug
@@ -62,7 +62,7 @@ test:
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --nprocesses 2 --debug
     # Corrupt a file
     - echo "Corrupting a file"
-    - rm -f munged/no-solvent/11507/run1-clone1.h5; touch munged/no-solvent/11507/run1-clone1.h5
+    - rm -f munged/11507/run1-clone1.h5; touch munged/11507/run1-clone1.h5
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug
 
 about:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -43,27 +43,48 @@ test:
     # Get some test data
     - git clone https://github.com/choderalab/fahmunge-testdata.git
     - cd fahmunge-testdata
-    # Testing
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug --validate
-    # TODO: Test to make sure expected output is found
-    - ls -ltr munged/11507
-    - ls -ltr munged/11431
-    # Test additional processing runs (shouldn't actually do anything)
-    - echo "Testing additional processing iterations"
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 2 --sleeptime 1 --debug
-    # Test running with time limit for processing
-    - echo "Testing with time limit"
-    - rm -rf munged
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 2 --time 10 --sleeptime 0 --debug
     # Test parallel
     - echo "Testing parallel processing"
     - rm -rf munged
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --nprocesses 2 --debug
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2
+    # Test restart after unpacking (shouldn't actually do anything)
+    - echo "Testing additional processing iterations"
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 2 --sleeptime 1
+    # TODO: Test to make sure expected output is found
+    - ls -ltr munged/11507
+    - ls -ltr munged/11431
+    # Remove unpacked files
+    - rm -rf PROJ11507/RUN?/CLONE?/results?
+    - rm -rf PROJ11419/RUN?/CLONE?/results?
+    # Test running with time limit for processing
+    - echo "Testing with time limit"
+    - rm -rf munged
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 2 --time 10 --sleeptime 0
     # Corrupt a file
     - echo "Corrupting a file"
     - rm -f munged/11507/run1-clone1.h5; touch munged/11507/run1-clone1.h5
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1
+    # TODO: Test to make sure expected output is found
+    - ls -ltr munged/11507
+    - ls -ltr munged/11431
+    - rm -rf munged
+    # Remove unpacked files
+    - rm -rf PROJ11507/RUN?/CLONE?/results?
+    - rm -rf PROJ11419/RUN?/CLONE?/results?
+    # Test serial debug mode
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --debug
+    # TODO: Test to make sure expected output is found
+    - ls -ltr munged/11507
+    - ls -ltr munged/11431
+    - rm -rf munged
+    # Remove unpacked files
+    - rm -rf PROJ11507/RUN?/CLONE?/results?
+    - rm -rf PROJ11419/RUN?/CLONE?/results?
+    # Test parallel with permanent deletion
+    - echo "Testing irreversible unpacking"
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --nprocesses 2 --unpack
 
 about:
   home: https://github.com/choderalab/fahmunge

--- a/fahmunge/__init__.py
+++ b/fahmunge/__init__.py
@@ -1,5 +1,6 @@
 from . import fah
 from . import automation
+from . import core21
 
 # versioneer
 from ._version import get_versions

--- a/fahmunge/cli.py
+++ b/fahmunge/cli.py
@@ -12,12 +12,14 @@ import fahmunge
 
 # Reads in a list of project details from a CSV file with Core17/18 FAH projects and munges them.
 
-def setup_worker(terminate_event):
+def setup_worker(terminate_event, delete_on_unpack):
     global global_terminate_event
     global_terminate_event = terminate_event
+    global global_delete_on_unpack
+    global_delete_on_unpack = delete_on_unpack
 
 def worker(args):
-    return fahmunge.core21.process_core21_clone(*args, terminate_event=global_terminate_event)
+    return fahmunge.core21.process_core21_clone(*args, terminate_event=global_terminate_event, delete_on_unpack=global_delete_on_unpack)
 
 def main():
     description = 'Munge FAH data'
@@ -30,8 +32,10 @@ def main():
         help='Output pathname for munged data')
     parser.add_argument('-n', '--nprocesses', metavar='NPROCESSES', dest='nprocesses', action='store', type=int, default=1,
         help='Number of threads to use (default: 1)')
-    parser.add_argument('-d', '--debug', dest='verbose', action='store_true', default=False,
-        help='Turn on debug output')
+    parser.add_argument('-d', '--debug', dest='debug', action='store_true', default=False,
+        help='Run in serial mode and turn on debug output')
+    parser.add_argument('-u', '--unpack', dest='delete_on_unpack', action='store_true', default=False,
+        help='Delete original results-###.tar.bz2 after unpacking; WARNING: THIS IS DANGEROUS AND COULD DELETE YOUR PRIMARY DATA.')
     parser.add_argument('-t', '--time', metavar='TIME', dest='time_limit', action='store', type=int, default=None,
         help='Process each project for no more than specified time (in seconds) before moving on to next project')
     parser.add_argument('-m', '--maxits', metavar='MAXITS', dest='maximum_iterations', action='store', type=int, default=None,
@@ -125,11 +129,10 @@ def main():
         clones_to_process = collections.deque()
         for (project, project_path, topology_filename, topology_selection) in projects.itertuples():
 
-            if args.verbose:
-                print('Project %s' % project)
-                print("  location: '%s'" % project_path)
-                print("  reference topology file: '%s'" % topology_filename)
-                print("  topology selection: '%s'" % topology_selection)
+            print('Project %s' % project)
+            print("  location: '%s'" % project_path)
+            print("  reference topology file: '%s'" % topology_filename)
+            print("  topology selection: '%s'" % topology_selection)
 
             # Form output path
             output_path = os.path.join(args.output_path, "%s/" % project)
@@ -164,56 +167,60 @@ def main():
         print('----------' * 8)
         print('Iteration %8d : Processing %d CLONEs...' % (iteration, len(clones_to_process)))
         print(datetime.datetime.now().isoformat())
-        print('Using %d threads' % args.nprocesses)
-        print('----------' * 8)
 
-        # Settings for thread processing
-        from multiprocessing import Pool, Event
-        print("Creating thread pool of %d threads..." % args.nprocesses)
-        terminate_event = Event()
-        pool = Pool(args.nprocesses, setup_worker, (terminate_event,))
+        if args.debug:
+            print('Using serial debug mode')
+            print('----------' * 8)
+            for packed_args in clones_to_process:
+                fahmunge.core21.process_core21_clone(*packed_args, delete_on_unpack=args.delete_on_unpack)
+        else:
+            # Settings for thread processing
+            print('Using %d threads' % args.nprocesses)
+            print('----------' * 8)
+            from multiprocessing import Pool, Event
+            print("Creating thread pool of %d threads..." % args.nprocesses)
+            terminate_event = Event()
+            pool = Pool(args.nprocesses, setup_worker, (terminate_event,args.delete_on_unpack))
 
-        try:
-            print("Starting asynchronous map operations...")
-            # TODO: Add serial version for debugging
-            #for packed_args in clones_to_process:
-            #    fahmunge.core21.process_core21_clone(*packed_args)
-            job = pool.map_async(worker, clones_to_process, chunksize=1)
 
-            sleep_interval = 5 # seconds between polling of multiprocessing pool
-            while( (not job.ready()) and (not terminate_event.is_set()) ):
-                time.sleep(sleep_interval)
-                # Terminate if maximum time has elapsed.
-                elapsed_time = time.time() - initial_time
-                if args.time_limit and (elapsed_time > args.time_limit):
-                    print('Elapsed time (%.1f s) exceeds timeout (%.1f s); signaling jobs to terminate.' % (elapsed_time, args.time_limit))
-                    terminate_event.set()
-                    terminate = True
-                # Terminate if a signal has been caught
-                if signal_handler.terminate:
-                    print('Signal caught; terminating.')
-                    terminate_event.set()
-                    terminate = True
+            try:
+                print("Starting asynchronous map operations...")
+                job = pool.map_async(worker, clones_to_process, chunksize=1)
 
-        except KeyboardInterrupt:
-            print("Caught KeyboardInterrupt, safely terminating workers. This may take several minutes. Please be patient to avoid data corruption.")
-            # Signal termination
-            terminate_event.set()
-            terminate = True
-            # Close down the multiprocessing pool
-            pool.close()
-            pool.join()
+                sleep_interval = 5 # seconds between polling of multiprocessing pool
+                while( (not job.ready()) and (not terminate_event.is_set()) ):
+                    time.sleep(sleep_interval)
+                    # Terminate if maximum time has elapsed.
+                    elapsed_time = time.time() - initial_time
+                    if args.time_limit and (elapsed_time > args.time_limit):
+                        print('Elapsed time (%.1f s) exceeds timeout (%.1f s); signaling jobs to terminate.' % (elapsed_time, args.time_limit))
+                        terminate_event.set()
+                        terminate = True
+                    # Terminate if a signal has been caught
+                    if signal_handler.terminate:
+                        print('Signal caught; terminating.')
+                        terminate_event.set()
+                        terminate = True
 
-        except Exception as e:
-            print('An exception occurred; terminating...')
-            # An exception occurred; terminate.
-            print(e)
-            raise e
+            except KeyboardInterrupt:
+                print("Caught KeyboardInterrupt, safely terminating workers. This may take several minutes. Please be patient to avoid data corruption.")
+                # Signal termination
+                terminate_event.set()
+                terminate = True
+                # Close down the multiprocessing pool
+                pool.close()
+                pool.join()
 
-        finally:
-            print("Cleaning up...")
-            pool.close()
-            pool.join()
+            except Exception as e:
+                print('An exception occurred; terminating...')
+                # An exception occurred; terminate.
+                print(e)
+                raise e
+
+            finally:
+                print("Cleaning up...")
+                pool.close()
+                pool.join()
 
         # Report completion of iteration
         print('Finished iteration %d.' % iteration)

--- a/fahmunge/cli.py
+++ b/fahmunge/cli.py
@@ -172,7 +172,11 @@ def main():
             print('Using serial debug mode')
             print('----------' * 8)
             for packed_args in clones_to_process:
-                fahmunge.core21.process_core21_clone(*packed_args, delete_on_unpack=args.delete_on_unpack)
+                fahmunge.core21.process_core21_clone(*packed_args, delete_on_unpack=args.delete_on_unpack, signal_handler=signal_handler)
+                # Terminate if instructed
+                if signal_handler.terminate:
+                    print('Signal caught; terminating.')
+                    exit(1)
         else:
             # Settings for thread processing
             print('Using %d threads' % args.nprocesses)

--- a/fahmunge/cli.py
+++ b/fahmunge/cli.py
@@ -6,6 +6,7 @@ import sys
 import collections
 import datetime
 import pandas as pd
+import mdtraj as md
 
 import fahmunge
 

--- a/fahmunge/cli.py
+++ b/fahmunge/cli.py
@@ -174,7 +174,9 @@ def main():
 
         try:
             print("Starting asynchronous map operations...")
-            #job = pool.map_async(fahmunge.core21.process_core21_clone, clones_to_process, chunksize=1)
+            # TODO: Add serial version for debugging
+            #for packed_args in clones_to_process:
+            #    fahmunge.core21.process_core21_clone(*packed_args)
             job = pool.map_async(worker, clones_to_process, chunksize=1)
 
             sleep_interval = 5 # seconds between polling of multiprocessing pool

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -17,6 +17,8 @@ from mdtraj.utils.contextmanagers import enter_temp_directory
 from mdtraj.utils import six
 from natsort import natsorted
 import time
+import copy
+import sys
 
 ################################################################################
 # ws9 core21 support
@@ -113,7 +115,7 @@ def ensure_result_packet_is_decompressed(result_packet, topology, atom_indices=N
     """
     # Return if this is just a directory
     if os.path.isdir(result_packet):
-        return
+        return result_packet
 
     # If this is a tarball, extract salient information.
     # Format: results-002.tar.bz2
@@ -192,6 +194,8 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
     * Include a safer way to substitute vars()
 
     """
+    print('Processing clone %s' % clone_path)
+    sys.stdout.flush()
 
     MAX_FILEPATH_LENGTH = 1024 # MAXIMUM FILEPATH LENGTH; this may be too short for some installations
 
@@ -200,25 +204,30 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
     signal_handler = SignalHandler()
 
     # Read the topology for the source WU
-    top = md.load(topology_filename % vars())
+    print('Reading topology from %s...' % topology_filename)
+    top = md.load(topology_filename)
     work_unit_topology = copy.deepcopy(top.topology) # extract topology
-    top.close()
+    del top # close file
+
+    # Check for early termination since topology reading might take a while
+    if terminate_event.is_set():
+        return
 
     # Determine atoms that will be written to trajectory
-    atom_indices = work_unit_topology.select()
+    atom_indices = work_unit_topology.select(atom_selection_string)
 
     # Create a new Topology for the atom subset to be written to the trajectory
     trajectory_topology = work_unit_topology.subset(atom_indices)
 
     # Glob file paths and return result files in sequential order.
-    result_packets = list_core21_result_packets()
+    result_packets = list_core21_result_packets(clone_path)
 
     # Return if there are no WUs to process
-    if len(sorted_folders) <= 0:
+    if len(result_packets) <= 0:
         return
 
     # Open trajectory for appending
-    trj_file = HDF5TrajectoryFile(output_filename, mode='a')
+    trj_file = HDF5TrajectoryFile(processed_trajectory_filename, mode='a')
 
     # Initialize new trajectory with topology and list of processed WUs if they are absent
     try:
@@ -231,12 +240,6 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
 
     # Process each WU, checking whether signal has been received after each.
     for result_packet in result_packets:
-        # Check that we haven't violated our filename length assumption
-        if len(filename) > MAX_FILEPATH_LENGTH:
-            msg = "Filename is longer than hard-coded MAX_FILEPATH_LENGTH limit (%d > %d). Increase MAX_FILEPATH_LENGTH and re-install." % (len(filename), MAX_FILEPATH_LENGTH)
-            print(msg)
-            raise Exception(msg)
-
         # Stop processing if signal handler indicates we should terminate
         if (signal_handler.terminate) or (terminate_event and terminate_event.is_set()):
             break
@@ -246,7 +249,13 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
             continue
 
         # If the result packet is compressed, decompress it and return the new directory name
-        result_packet = ensure_result_packet_is_decompressed(result_packet)
+        result_packet = ensure_result_packet_is_decompressed(result_packet, work_unit_topology)
+
+        # Check that we haven't violated our filename length assumption
+        if len(result_packet) > MAX_FILEPATH_LENGTH:
+            msg = "Filename is longer than hard-coded MAX_FILEPATH_LENGTH limit (%d > %d). Increase MAX_FILEPATH_LENGTH and re-install." % (len(result_packet), MAX_FILEPATH_LENGTH)
+            print(msg)
+            raise Exception(msg)
 
         # Stop processing if signal handler indicates we should terminate
         if (signal_handler.terminate) or (terminate_event and terminate_event.is_set()):
@@ -255,8 +264,8 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
         # Process the work unit
         # TODO: Write to logger instead of printing to terminal
         # TODO: We could conceivably also check for early termination in the chunk loop if we carefully track the last chunk processed as well.
-        print("   Processing %s" % folder)
-        xtc_filename = os.path.join(folder, "frames.xtc")
+        print("   Processing %s" % result_packet)
+        xtc_filename = os.path.join(result_packet, "positions.xtc")
         for chunk in md.iterload(xtc_filename, top=work_unit_topology, atom_indices=atom_indices, chunk=chunksize):
             trj_file.write(coordinates=chunk.xyz, cell_lengths=chunk.unitcell_lengths, cell_angles=chunk.unitcell_angles, time=chunk.time)
         # Record that we've processed the WU

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -171,7 +171,7 @@ def ensure_result_packet_is_decompressed(result_packet, topology, atom_indices=N
         # Return updated result packet directory name
         return new_result_packet
 
-def process_core21_clone(clone_path, topology_filename, processed_trajectory_filename, atom_selection_string, terminate_event=None, delete_on_unpack=False, chunksize=10):
+def process_core21_clone(clone_path, topology_filename, processed_trajectory_filename, atom_selection_string, terminate_event=None, delete_on_unpack=False, chunksize=10, signal_handler=None):
     """
     Process core21 result packets in a CLONE, concatenating to a specified trajectory.
     This will append to the specified trajectory if it already exists.
@@ -199,6 +199,8 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
         WARNING: THIS COULD BE DANGEROUS
     chunksize : int, optional, default=10
         Chunksize (in number of frames) to use for mdtraj.iterload reading of trajectory
+    signal_handler : SignalHandler, optional, default=None
+        If None, a new SignalHandler object will be created.
 
     TODO
     ----
@@ -212,9 +214,8 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
 
     MAX_FILEPATH_LENGTH = 1024 # MAXIMUM FILEPATH LENGTH; this may be too short for some installations
 
-    # TODO: Either spawn a new thread equipped with a signal handler
-    # or make sure we are inside a newly spawned thread
-    signal_handler = SignalHandler()
+    if not signal_handler:
+        signal_handler = SignalHandler()
 
     # Read the topology for the source WU
     # TODO: Only read topology if we have not processed all the WU packets

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -282,6 +282,6 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
     # Sync the trajectory file to flush all data to disk
     trj_file.close()
 
-def test_worker(*args, **kwargs):
-    print('args: %s' % args)
-    print('kwargs: %s' % kwargs)
+    # Make sure we tell everyone to terminate if we are terminating
+    if signal_handler.terminate and (not terminate_event.is_set()):
+        terminate_event.set()

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -283,5 +283,5 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
     trj_file.close()
 
     # Make sure we tell everyone to terminate if we are terminating
-    if signal_handler.terminate and (not terminate_event.is_set()):
+    if signal_handler.terminate and terminate_event:
         terminate_event.set()

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -194,8 +194,9 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
     * Include a safer way to substitute vars()
 
     """
-    print('Processing clone %s' % clone_path)
-    sys.stdout.flush()
+    # Check for early termination since topology reading might take a while
+    if terminate_event.is_set():
+        return
 
     MAX_FILEPATH_LENGTH = 1024 # MAXIMUM FILEPATH LENGTH; this may be too short for some installations
 
@@ -273,3 +274,7 @@ def process_core21_clone(clone_path, topology_filename, processed_trajectory_fil
 
     # Sync the trajectory file to flush all data to disk
     trj_file.close()
+
+def test_worker(*args, **kwargs):
+    print('args: %s' % args)
+    print('kwargs: %s' % kwargs)

--- a/fahmunge/core21.py
+++ b/fahmunge/core21.py
@@ -1,0 +1,266 @@
+"""
+Support for core21/core22 projects in ws9 and earlier format.
+
+"""
+##############################################################################
+# imports
+##############################################################################
+
+from __future__ import print_function, division
+import os, os.path
+import glob
+import tarfile
+from mdtraj.formats.hdf5 import HDF5TrajectoryFile
+import mdtraj as md
+import tables
+from mdtraj.utils.contextmanagers import enter_temp_directory
+from mdtraj.utils import six
+from natsort import natsorted
+import time
+
+################################################################################
+# ws9 core21 support
+################################################################################
+
+import signal
+import time
+
+class SignalHandler:
+    """
+    """
+    terminate = False
+    def __init__(self):
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+    def exit_gracefully(self, signum, frame):
+        self.terminate = True
+
+def list_core21_result_packets(clone_path):
+    """
+    Create an ordered list of core21 result packets in the specified CLONE path.
+
+    Parameters
+    ----------
+    clone_path : str
+        Path to CLONE directory containing ws8/ws9 WUs
+
+    Returns
+    -------
+    folders : list of str
+        List of core21 result packets, either tarballs (ws7/8) or directories (ws9),
+        sorted in order of increasing FRAME number.
+
+    """
+    # Get a list of all files in the directory
+    file_list = os.listdir(clone_path)
+
+    # Create a list of result packets
+    result_packets = list()
+
+    # Iterate over possible result packets
+    max_frames = len(file_list)
+    for frame_index in range(max_frames):
+        # Prioritize uncompressed packets over compressed packets
+        result_packet = os.path.join(clone_path, 'results%d' % frame_index)
+        if os.path.exists(result_packet):
+            result_packets.append(result_packet)
+            continue
+
+        # Check if compressed packet exists
+        result_packet = os.path.join(clone_path, 'results-%03d.tar.bz2' % frame_index)
+        if os.path.exists(result_packet):
+            result_packets.append(result_packet)
+            continue
+
+        # No more contiguous frames; terminate
+        break
+
+    return result_packets
+
+def ensure_result_packet_is_decompressed(result_packet, topology, atom_indices=None, chunksize=10):
+    """
+    Ensure that the specified result packet is decompressed.
+
+    If this is a ws7/ws8 compressed result packet, safely convert it to uncompressed:
+    * decompress it into a temporary directory
+    * move it into place
+    * verify integrity of files
+    * unlink (delete) the old result packet if everything looks OK
+
+    If this is a directory, this function returns immediately.
+
+    .. warning: This will irreversibly delete the compressed work packet, replacing
+    it with an uncompressed one.
+
+    Parameters
+    ----------
+    result_packet : str
+        Path to original result packet
+    topology : mdtraj.Topology
+        Topology to use for verifying integrity of trajectory
+    atom_indices : list of int, optional, default=None
+        Atom indices to read when verifying integrity of trajectory
+        If None, all atoms will be read.
+    chunksize : int, optional, default=10
+        Number of frames to read each call to mdtraj.iterload for verifying trajectory integrity
+
+    Returns
+    -------
+    result_packet : str
+        Path to new result packet directory
+
+    """
+    # Return if this is just a directory
+    if os.path.isdir(result_packet):
+        return
+
+    # If this is a tarball, extract salient information.
+    # Format: results-002.tar.bz2
+    (basepath, filename) = os.path.split(result_packet)
+    if not re.match(r'results-\d\d\d.tar.bz2', filename):
+        raise Exception("Compressed results packet filename '%s' does not match expected format (results-001.tar.bz2)" % result_packet)
+    frame_number = int(re.match(r'results-(\d+).tar.bz2', filename).group(0))
+
+    # Extract frames from trajectory in a temporary directory
+    absfilename = os.path.abspath(filename)
+    with enter_temp_directory():
+        # Create target directory
+        extracted_archive_directory = 'results'
+
+        # Extract all contents
+        archive = tarfile.open(absfilename, mode='r:bz2')
+        archive.extractall(path=extracted_archive_directory)
+
+        # Create new result packet name
+        new_result_packet = os.path.join(basepath, 'results%d' % frame_number)
+
+        # Move directory into place
+        os.shutil.move(extracted_archive_directory, new_result_packet)
+
+        # Verify integrity of archive contents
+        xtc_filename = os.path.join(new_result_packet, 'positions.xtc')
+        if not os.path.exists(xtc_filename):
+            raise Exception("Result packet archive '%s' does not contain positions.xtc; aborting unpacking.")
+        try:
+            for chunk in md.iterload(xtc_filename, top=topology, atom_indices=atom_indices, chunk=chunksize):
+                pass
+        except Exception as e:
+            msg = "Result packet archive '%s' failed trajectory integrity check; aborting unpacking.\n"
+            msg += str(e)
+            raise Exception(msg)
+
+        # Cleanup archive object
+        del archive
+
+        # Remove archive permanently
+        # TODO: Uncomment this after rigorous testing
+        #os.unlink(result_packet)
+
+        # Return updated result packet directory name
+        return new_result_packet
+
+def process_core21_clone(clone_path, topology_filename, processed_trajectory_filename, atom_selection_string, terminate_event=None, chunksize=10):
+    """
+    Process core21 result packets in a CLONE, concatenating to a specified trajectory.
+    This will append to the specified trajectory if it already exists.
+
+    Note
+    ----
+    * ws9 stores core21 result packets in an uncompressed directory. Original result packets are left untouched.
+    * ws8 and earlier versions store result packets in compressed archives; this method will safely unpack them and remove the original compressed files.
+    * An exception will be raised if something goes wrong with processing. The calling process will have to catch this and abort CLONE processing.
+
+    Parameters
+    ----------
+    clone_path : str
+        Source path to CLONE data directory
+    topology_filename : str
+        Path to PDB or other file containing topology information
+    processed_trajectory_filename : str
+        Path to concatenated stripped trajectory
+    atom_selection_string : str
+        MDTraj DSL specifying which atoms should be stripped from source WUs.
+    terminate_event : multiprocessing.Event, optional, default=None
+        If specified, will terminate early if terminate_event.is_set() is True
+    chunksize : int, optional, default=10
+        Chunksize (in number of frames) to use for mdtraj.iterload reading of trajectory
+
+    TODO
+    ----
+    * Add unpacking step to support ws9
+    * Include a safer way to substitute vars()
+
+    """
+
+    MAX_FILEPATH_LENGTH = 1024 # MAXIMUM FILEPATH LENGTH; this may be too short for some installations
+
+    # TODO: Either spawn a new thread equipped with a signal handler
+    # or make sure we are inside a newly spawned thread
+    signal_handler = SignalHandler()
+
+    # Read the topology for the source WU
+    top = md.load(topology_filename % vars())
+    work_unit_topology = copy.deepcopy(top.topology) # extract topology
+    top.close()
+
+    # Determine atoms that will be written to trajectory
+    atom_indices = work_unit_topology.select()
+
+    # Create a new Topology for the atom subset to be written to the trajectory
+    trajectory_topology = work_unit_topology.subset(atom_indices)
+
+    # Glob file paths and return result files in sequential order.
+    result_packets = list_core21_result_packets()
+
+    # Return if there are no WUs to process
+    if len(sorted_folders) <= 0:
+        return
+
+    # Open trajectory for appending
+    trj_file = HDF5TrajectoryFile(output_filename, mode='a')
+
+    # Initialize new trajectory with topology and list of processed WUs if they are absent
+    try:
+        # TODO: Switch from pytables StringAtom to arbitrary-length string
+        # http://www.pytables.org/usersguide/datatypes.html
+        trj_file._create_earray(where='/', name='processed_folders',atom=trj_file.tables.StringAtom(MAX_FILEPATH_LENGTH), shape=(0,))
+        trj_file.topology = trajectory_topology # assign topology
+    except trj_file.tables.NodeError:
+        pass
+
+    # Process each WU, checking whether signal has been received after each.
+    for result_packet in result_packets:
+        # Check that we haven't violated our filename length assumption
+        if len(filename) > MAX_FILEPATH_LENGTH:
+            msg = "Filename is longer than hard-coded MAX_FILEPATH_LENGTH limit (%d > %d). Increase MAX_FILEPATH_LENGTH and re-install." % (len(filename), MAX_FILEPATH_LENGTH)
+            print(msg)
+            raise Exception(msg)
+
+        # Stop processing if signal handler indicates we should terminate
+        if (signal_handler.terminate) or (terminate_event and terminate_event.is_set()):
+            break
+
+        # Skip this WU if we have already processed it
+        if six.b(result_packet) in trj_file._handle.root.processed_folders:  # On Py3, the pytables list of filenames has type byte (e.g. b"hey"), so we need to deal with this via six.
+            continue
+
+        # If the result packet is compressed, decompress it and return the new directory name
+        result_packet = ensure_result_packet_is_decompressed(result_packet)
+
+        # Stop processing if signal handler indicates we should terminate
+        if (signal_handler.terminate) or (terminate_event and terminate_event.is_set()):
+            break
+
+        # Process the work unit
+        # TODO: Write to logger instead of printing to terminal
+        # TODO: We could conceivably also check for early termination in the chunk loop if we carefully track the last chunk processed as well.
+        print("   Processing %s" % folder)
+        xtc_filename = os.path.join(folder, "frames.xtc")
+        for chunk in md.iterload(xtc_filename, top=work_unit_topology, atom_indices=atom_indices, chunk=chunksize):
+            trj_file.write(coordinates=chunk.xyz, cell_lengths=chunk.unitcell_lengths, cell_angles=chunk.unitcell_angles, time=chunk.time)
+        # Record that we've processed the WU
+        trj_file._handle.root.processed_folders.append([result_packet])
+
+    # Sync the trajectory file to flush all data to disk
+    trj_file.close()

--- a/fahmunge/fah.py
+++ b/fahmunge/fah.py
@@ -1,27 +1,6 @@
-##############################################################################
-# MDTraj: A Python Library for Loading, Saving, and Manipulating
-#         Molecular Dynamics Trajectories.
-# Copyright 2012-2013 Stanford University and the Authors
-#
-# Authors: Kyle A. Beauchamp
-# Contributors:
-#
-# MDTraj is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 2.1
-# of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with MDTraj. If not, see <http://www.gnu.org/licenses/>.
-##############################################################################
-
 """
 Code for merging and munging trajectories from FAH datasets.
+
 """
 ##############################################################################
 # imports


### PR DESCRIPTION
I've totally overhauled how core21 work units are processed.

Parallelization is now handled by clone, though clone processing can be interrupted early by signals (`SIGINT`, `SIGTERM`) or by a multiprocessing `Event` from the master process to signal termination after a certain amount of time has elapsed or a keyboard interrupt occurs.

This is still undergoing heavy testing.