### PR TITLE
Add feature to delete XML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ More advanced usage allows additional arguments to be specified:
 * `--maxits <MAXITS>` will cause the munging pipeline to run for the specified number of iterations and then exit. This can be useful for debugging. Without specifying this option, munging will run indefinitely.
 * `--sleeptime <SLEEPTIME>` will cause munging to sleep for the specified number of seconds if no work was done in this iteration (default:3600).
 * `--validate` will validate the choice of `topology_selection` MDTraj DSL topology selection queries to make sure they are valid; note that this may take a significant amount of time, so is optional behavior
-* `--compress-xml` will compress `.xml` files after unpacking them from old-WS-style result packages to save space
+* `--xml compress` will compress `.xml` files after unpacking them from old-WS-style result packages to save space; `--xml delete` will delete `.xml` files after unpacking
+* `--delete-tarballs` will delete the old `.tar.bz2` WUs after unpacking them from old-WS-style result packages to save space
 
 #### Usage on `choderalab` Folding@home servers
 
 1.  Login to work server using the usual FAH login
 2.  Check if script is running (`screen -r -d`).  If True, stop here.
 3.  Start a screen session
-4.  Run with: `munge-fah-data --projects /data/choderalab/fah/projects.csv --outpath /data/choderalab/fah/munged-data --time 600 --nprocesses 16`
+4.  Run with: `munge-fah-data --projects /data/choderalab/fah/projects.csv --outpath /data/choderalab/fah/munged-data --time 600 --nprocesses 16 --delete-on-unpack --xml compress`
 5.  To stop, control c when the script is in the "sleep" phase
 
 #### How it works

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   build:
     - setuptools
     - python
-    
+
   run:
     - python
     - numpy
@@ -41,10 +41,10 @@ test:
     # Test parallel
     - echo "Testing parallel processing"
     - rm -rf munged
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2 --compress-xml
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2 --xml compress
     # Test restart after unpacking (shouldn't actually do anything)
     - echo "Testing additional processing iterations"
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --validate --nprocesses 2  --xml compress
     - munge-fah-data --projects projects.csv --outpath munged --maxits 1
     - munge-fah-data --projects projects.csv --outpath munged --maxits 2 --sleeptime 1
     # TODO: Test to make sure expected output is found
@@ -79,8 +79,8 @@ test:
     - rm -rf PROJ11507/RUN?/CLONE?/results?
     - rm -rf PROJ11419/RUN?/CLONE?/results?
     # Test parallel with permanent deletion
-    - echo "Testing irreversible unpacking"
-    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --nprocesses 2 --unpack
+    - echo "Testing irreversible unpacking with deletion of unpacked XML files"
+    - munge-fah-data --projects projects.csv --outpath munged --maxits 1 --nprocesses 2 --xml delete --delete-tarballs
 
 about:
   home: https://github.com/choderalab/fahmunge


### PR DESCRIPTION
This change
* Change `--unpack` to `--delete-tarballs`; this option deletes `.tar.bz2` files from old WS style WUs after unpacking them 
* Removed `--compress-xml`, and replaced it with `--xml compress` or `-xml delete`

The new recommended syntax for `plfah2` is 
```bash
munge-fah-data --projects /data/choderalab/fah/projects.csv --outpath /data/choderalab/fah/munged-final --nprocesses 16 --delete-on-unpack --xml delete`
```